### PR TITLE
feat: add metric for packet sending 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,8 @@ jobs:
           chmod +x build.sh
           bash build.sh
           mkdir -p build-binary
-          tar -czvf omil-$(git rev-parse --short HEAD).tar.gz build
+          cp -r build omil
+          tar -czvf omil-$(git rev-parse --short HEAD).tar.gz omil
           mv omil-$(git rev-parse --short HEAD).tar.gz build-binary
 
       - name: Upload

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,8 @@ jobs:
           chmod +x build.sh
           bash build.sh
           mkdir -p build-binary
-          tar -czvf omil-$(git rev-parse --short HEAD).tar.gz build
+          cp -r build omil
+          tar -czvf omil-$(git rev-parse --short HEAD).tar.gz omil
           mv omil-$(git rev-parse --short HEAD).tar.gz build-binary
 
       - name: Upload

--- a/main.go
+++ b/main.go
@@ -33,7 +33,10 @@ func mainAction(ctx *cli.Context) error {
 
 	monitors := make([]*icmp.Monitor, 0, len(conf.Targets))
 	for _, t := range conf.Targets {
-		monitor, err := icmp.NewMonitor(t.Host, conf.Hostname, t.Name, time.Second, time.Hour*12, metricClient)
+		// As pinger stores all packets data in memory,
+		// so too long timeout may cause high memory usage.
+		// Just let it stop and restart.
+		monitor, err := icmp.NewMonitor(t.Host, conf.Hostname, t.Name, time.Second, time.Minute*60, metricClient)
 		if err != nil {
 			logrus.WithError(err).WithFields(logrus.Fields{
 				"target_host": t.Host,


### PR DESCRIPTION
Now service will send data points when sending packets, so we can calculate packet drop ratio for each target host even if no packets are received.